### PR TITLE
Add GitHub workflow to build and publish docker image

### DIFF
--- a/.github/workflows/docker-gke.yml
+++ b/.github/workflows/docker-gke.yml
@@ -1,0 +1,54 @@
+# This workflow will build a docker image and publish it to Google Container Registry.
+# Based on https://github.com/google-github-actions/setup-gcloud/tree/master/example-workflows/gke
+
+name: Build docker image and publish to GKE
+
+on: push
+
+env:
+  PROJECT_ID: ${{ secrets.GKE_PROJECT }}
+  GKE_CLUSTER: cluster-1
+  GKE_ZONE: europe-west3-a
+  IMAGE: object-detection-tf2
+
+jobs:
+  build-and-publish:
+    name: Build and publish docker image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Setup gcloud CLI
+    - uses: google-github-actions/setup-gcloud@v0.2.0
+      with:
+        service_account_key: ${{ secrets.GKE_SA_KEY }}
+        project_id: ${{ env.PROJECT_ID }}
+
+    # Configure Docker to use the gcloud command-line tool as a credential
+    # helper for authentication
+    - run: |-
+        gcloud --quiet auth configure-docker
+
+    # Get the GKE credentials so we can deploy to the cluster
+    - uses: google-github-actions/get-gke-credentials@v0.2.1
+      with:
+        cluster_name: ${{ env.GKE_CLUSTER }}
+        location: ${{ env.GKE_ZONE }}
+        credentials: ${{ secrets.GKE_SA_KEY }}
+
+    # Build the Docker image
+    - name: Build
+      run: |-
+        docker build \
+          --file research/object_detection/dockerfiles/tf2/Dockerfile \
+          --tag "eu.gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA" \
+          --build-arg GITHUB_SHA="$GITHUB_SHA" \
+          --build-arg GITHUB_REF="$GITHUB_REF" \
+          .
+
+    # Push the Docker image to Google Container Registry
+    - name: Publish
+      run: |-
+        docker push "eu.gcr.io/$PROJECT_ID/$IMAGE:$GITHUB_SHA"


### PR DESCRIPTION
Set up a GitHub workflow that will build a docker image with our
version of the object detection code and publish it to Google Cloud
Engine using the git commit SHA as tag. That should help to relate
docker images with code versions.

The setup is based on
https://github.com/google-github-actions/setup-gcloud/blob/master/example-workflows/gke/