### PR TITLE
Enable memory growth for physical GPUs

### DIFF
--- a/research/object_detection/model_main_tf2.py
+++ b/research/object_detection/model_main_tf2.py
@@ -75,7 +75,17 @@ def main(unused_argv):
   flags.mark_flag_as_required('model_dir')
   flags.mark_flag_as_required('pipeline_config_path')
   tf.config.set_soft_device_placement(True)
-
+  physical_gpus = tf.config.experimental.list_physical_devices('GPU')
+  if physical_gpus:
+    try:
+      for gpu in physical_gpus:
+          tf.config.experimental.set_memory_growth(device, True)
+      logical_gpus = tf.config.experimental.list_logical_devices('GPU')
+      print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
+    except RuntimeError as e:
+      print(
+          f'Virtual devices must be set before GPUs have been initialized: {e}'
+          )
   if FLAGS.checkpoint_dir:
     model_lib_v2.eval_continuously(
         pipeline_config_path=FLAGS.pipeline_config_path,


### PR DESCRIPTION
Allocate memory on GPU only while needed by setting memory growth
to `True`. Without allowing memory growth, TensorFlow pre-allocates
~90% of the GPU memory which would later result in the error 'failed
to create cublas handle'.